### PR TITLE
Fix for Quantity Rounding Issue in BOM Creation

### DIFF
--- a/esoft_bom_importer/utils.py
+++ b/esoft_bom_importer/utils.py
@@ -7,7 +7,7 @@ from frappe.utils import now
 from datetime import datetime
 from frappe.desk.treeview import get_all_nodes
 from collections import defaultdict
-
+import math
 
 def create_bom_from_hierarchy(
     bom_structure, current_index, total_length, history, should_proceed=True
@@ -572,7 +572,12 @@ def calculate_powder_item_qty(item, parent_item):
     if not coverage or not area:
         return 0.1
 
-    return (area / coverage)
+    qty = area / coverage
+
+    if 0 < qty < 0.001:
+        return 0.001
+
+    return math.ceil(qty * 1000) / 1000
 
 def _validate_item_group(group_list, item_group):
     if item_group not in group_list:


### PR DESCRIPTION
We had an issue in the BOM creation process where calculated quantities were being displayed as 0.000 when the actual computed value was a very small decimal (for example, 0.00045). This was happening due to standard rounding behavior, which rounded small values down to zero.

To resolve this, we updated the quantity calculation logic to always round up to three decimal places and enforce a minimum quantity of 0.001. This ensures that even very small calculated quantities are not lost during rounding and are displayed correctly in the system.

As a result, values such as 0.00045 are now correctly shown as 0.001, preventing zero-quantity entries and ensuring accurate material consumption in the BOM.